### PR TITLE
Display the correct name on the graph overlay

### DIFF
--- a/public/j/tasseo.js
+++ b/public/j/tasseo.js
@@ -59,6 +59,7 @@ function refreshData() {
 
       // update our graph
       graphs[n].update();
+      alias = metrics[n].alias || metrics[n].target;
       $(".overlay-name" + n).text(alias);
       $(".overlay-number" + n).text(parseInt(datum[n][datum.length].y));
       if (metrics[n].unit) {


### PR DESCRIPTION
The alias variable doesn't seem to be updated properly, so if you use aliases all the graphs end up with the same alias when the graphs update (the alias of the last graph in the metrics list)
