### PR TITLE
read config file for graphite URL

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+tasseo.yaml

--- a/config/tasseo.yaml-sample
+++ b/config/tasseo.yaml-sample
@@ -1,0 +1,1 @@
+:graphite: http://graphite-server

--- a/public/d/.gitignore
+++ b/public/d/.gitignore
@@ -1,7 +1,1 @@
-var metrics =
-[
-  {
-    "alias": "test metric",
-    "target": "will.not.work"
-  }
-];
+*.js

--- a/views/index.haml
+++ b/views/index.haml
@@ -37,7 +37,7 @@
     - if dashboard
       #main
         :javascript
-          var url = "#{ENV['GRAPHITE_URL']}";
+          var url = "#{url}";
         %script{ :type => "text/javascript", :src => "/d/#{dashboard}.js" }
         %script{ :type => "text/javascript", :src => "/j/tasseo.js" }
     - else

--- a/web.rb
+++ b/web.rb
@@ -1,6 +1,7 @@
 require 'sinatra'
 require 'rack-ssl-enforcer'
 require 'haml'
+require 'yaml'
 
 module Tasseo
   class Application < Sinatra::Base
@@ -12,6 +13,7 @@ module Tasseo
     end
 
     before do
+      @config = YAML.load_file(File.expand_path("../config/tasseo.yaml", __FILE__))
       find_dashboards
     end
 
@@ -29,6 +31,7 @@ module Tasseo
         haml :index, :locals => {
           :dashboard => nil,
           :list => @dashboards,
+          :url  => @config[:graphite],
           :error => nil
         }
       else
@@ -43,7 +46,10 @@ module Tasseo
     get %r{/([\S]+)} do
       path = params[:captures].first
       if @dashboards.include?(path)
-        haml :index, :locals => { :dashboard => path }
+        haml :index, :locals => { 
+          :dashboard => path,
+          :url => @config[:graphite]
+        }
       else
         haml :index, :locals => {
           :dashboard => nil,


### PR DESCRIPTION
I wanted to use apache + passenger to serve up Tasseo and I needed another way to pass the graphite URL. I realized that a config file might be needed at some point so I added this for my own benefit. Include it if you like it. I also have a sample apache vhost config in another commit on my fork.
