### PR TITLE
add support for hiding the toolbar

### DIFF
--- a/public/j/tasseo.js
+++ b/public/j/tasseo.js
@@ -202,6 +202,10 @@ constructUrl(period);
 var myTheme = (typeof theme == 'undefined') ? 'default' : theme;
 if (myTheme === "dark") { enableNightMode(); }
 
+// hide our toolbar if necessary
+var toolbar = (typeof toolbar == 'undefined') ? true : toolbar;
+if (!toolbar) { $('div#toolbar').css('display', 'none'); }
+
 // initial load screen
 refreshData();
 for (var i=0; i<graphs.length; i++) {


### PR DESCRIPTION
I'd like to hide the toolbar when we use tasseo on some of our screens (info radiators) that expect no user input. I generally zoom the browser in a lot to create a giant dashboard, but the toolbar is wasted space and adds clutter.

This patch allows you to add a line to your dashboard js to turn off toolbars:

`var toolbar = false`

I thought about adding a tiny link to the UI for this (e.g. [show]/[hide]), but the js route seemed like a simple and unobtrusive solution with no need to add more controls to the interface. It does mean that _no-one_ gets controls for the dashboard, but I'm mostly happy to accept this limitation :)
