### PR TITLE
using jsonp to allow for crossdomain xhr requests

### DIFF
--- a/public/j/tasseo.js
+++ b/public/j/tasseo.js
@@ -49,7 +49,7 @@ function constructUrl(period) {
     }
     targets += ('target=' + encodeURI(realMetrics[i].target));
   }
-  myUrl = url + '/render/?' + targets + '&from=-' + period + 'minutes&format=json';
+  myUrl = url + '/render/?' + targets + '&from=-' + period + 'minutes&format=json&jsonp=?';
 }
 
 // refresh the graph
@@ -114,7 +114,7 @@ function getData(cb) {
         xhr.setRequestHeader("Authorization", "Basic " + base64);
       }
     },
-    dataType: 'json',
+    dataType: 'jsonp',
     error: function(xhr, textStatus, errorThrown) { console.log(errorThrown); },
     url: myUrl
   }).done(function(d) {


### PR DESCRIPTION
Graphite seems to [support jsonp](https://bugs.launchpad.net/graphite/+bug/862598) as of late. I changed tasseo.js to use jsonp in the jQuery.ajax xhr call. 

This allows tasseo to be used on another machine than the graphite machine. 
