### PR TITLE
Add ability to nest dashboards within subdirectories of public/d

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The default behavior is designed for a Carbon retention policy with a 1-second r
 
 ### Examples
 
-Creating your own dashboard is as simple as dropping a JSON file into the `public/d` directory, committing it, and pushing the code to a Heroku app. The name of your file (minus the `.js` suffix) becomes the name of your dashboard. Here's an example configuration that you could put in e.g. `public/d/example.js`:
+Creating your own dashboard is as simple as dropping a JSON file into the `public/d` directory(or a subdirectory of `public/d`), committing it, and pushing the code to a Heroku app. The name of your file (minus the `.js` suffix) becomes the name of your dashboard. Here's an example configuration that you could put in e.g. `public/d/example.js`:
 
 ```json
 var metrics =

--- a/views/index.haml
+++ b/views/index.haml
@@ -48,4 +48,4 @@
           %ul
             - list.each do |d|
               %li
-                %a{ :href => "/#{d}" } #{d}
+                %a{ :href => "#{path}/#{d}" } #{d}

--- a/web.rb
+++ b/web.rb
@@ -11,48 +11,60 @@ module Tasseo
       use Rack::SslEnforcer if ENV['FORCE_HTTPS']
     end
 
-    before do
-      find_dashboards
-    end
-
     helpers do
-      def find_dashboards
+      def find_dashboards(path='')
+        searchpath = "public/d/" + path
+        @ignore = ['.', '..', '.gitignore']
         @dashboards = []
-        Dir.foreach("public/d").grep(/\.js/).sort.each do |f|
-          @dashboards.push(f.split(".").first)
+        Dir.foreach(searchpath).sort.each do |f|
+          next if @ignore.include?(f)
+          if File.directory?(searchpath + f)
+            @dashboards.push(f)
+          else
+            @dashboards.push(f.split(".").first)
+          end
+        end
+      end
+
+      def handle_dir(path='')
+        find_dashboards(path)
+        if !@dashboards.empty?
+          haml :index, :locals => {
+            :dashboard => nil,
+            :list => @dashboards,
+            :error => nil,
+            :path  => path
+          }
+        else
+          haml :index, :locals => {
+            :dashboard => nil,
+            :list => nil,
+            :error => 'No dashboard files found.'
+          }
         end
       end
     end
 
     get '/' do
-      if !@dashboards.empty?
-        haml :index, :locals => {
-          :dashboard => nil,
-          :list => @dashboards,
-          :error => nil
-        }
-      else
-        haml :index, :locals => {
-          :dashboard => nil,
-          :list => nil,
-          :error => 'No dashboard files found.'
-        }
-      end
+      handle_dir()
     end
 
     get %r{/([\S]+)} do
       path = params[:captures].first
-      if @dashboards.include?(path)
+      if File.exists?("public/d/" + path + ".js")
         haml :index, :locals => { :dashboard => path }
+      elsif File.directory?("public/d/" + path)
+        find_dashboards(path)
+        handle_dir('/' + path)
       else
+        find_dashboards()
         haml :index, :locals => {
           :dashboard => nil,
           :list => @dashboards,
-          :error => 'That dashboard does not exist.'
+          :error => 'That dashboard does not exist.',
+          :path  => path
         }
       end
     end
-
   end
 end
-


### PR DESCRIPTION
Enable the ability to have dashboards nested within subdirectories of the public/d directory. This allows you to organize dashboards and drill down to find a specific dashboard, much like you do today inside the graphite web UI.

I'm not much of a rubyist, so if there's a more correct way to implement the same functionality, then please use that instead.
