### PR TITLE
/health support

### DIFF
--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -18,7 +18,12 @@ describe Tasseo::Application do
 
     it 'should respond with the text "ok"' do
       get '/health'
-      last_response.body.should eq('ok')
+      last_response.body.should eq({'status' => 'ok'}.to_json)
+    end
+
+    it 'should be JSON' do
+      get '/health'
+      last_response.headers['Content-Type'].should eq('application/json;charset=utf-8')
     end
 
     context 'GITHUB_AUTH_ORGANIZATION is set' do

--- a/web.rb
+++ b/web.rb
@@ -60,7 +60,8 @@ module Tasseo
     end
 
     get '/health' do
-      'ok'
+      content_type :json
+      {'status' => 'ok'}.to_json
     end
 
     get %r{/([\S]+)} do


### PR DESCRIPTION
It'd be nice to have a normalized `/health` for a monitoring service to hit.  Tests included, also takes into the GH oauth stuff.
