### PR TITLE
update Thin to get it compiling again with Ubuntu 12.04

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "sinatra"
-gem "thin"
+gem "thin", "~> 1.5.0"
 gem "rack-ssl-enforcer"
 gem "haml"
 gem 'sinatra_auth_github'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.3.2)
-    daemons (1.1.8)
+    daemons (1.1.9)
     diff-lcs (1.1.3)
-    eventmachine (0.12.10)
+    eventmachine (1.0.0)
     faraday (0.8.4)
       multipart-post (~> 1.1)
     faraday_middleware (0.8.8)
@@ -49,7 +49,7 @@ GEM
       sinatra (~> 1.0)
       warden-github (~> 0.9.0)
       yajl-ruby (~> 1.1)
-    thin (1.3.1)
+    thin (1.5.0)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
@@ -76,4 +76,4 @@ DEPENDENCIES
   rspec
   sinatra
   sinatra_auth_github
-  thin
+  thin (~> 1.5.0)


### PR DESCRIPTION
The version currently required by tasseo cannot be compiled on a Ubuntu 12.04 box (https://github.com/macournoyer/thin/issues/131).

If we use the version 1.5.0 it works.
