### PR TITLE
add ./lib to the load path, otherwhise passenger won't find the app

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,4 @@
+$LOAD_PATH << './lib'
 require "tasseo/web"
 
 run Tasseo::Web


### PR DESCRIPTION
without this change, Passenger is unable to `require "tasseo/web"`.
I don't know whether this change influences installs on Heroku, but it should not... I think :smile:
