### PR TITLE
The path to the dashboards should be build relatively.

### DIFF
--- a/lib/tasseo/web.rb
+++ b/lib/tasseo/web.rb
@@ -35,7 +35,7 @@ module Tasseo
       end
 
       def dashboards_dir
-        'dashboards'
+        File.expand_path('../../../dashboards', __FILE__)
       end
 
       def find_dashboards


### PR DESCRIPTION
When running the application from Rack, the daemon will change the
working directory to "/".  Because of that, the application can't find
the directory with all the dashboards.

By building the path from the actual library path, we can be sure to
always find our dashboards.

This was tested with the following scenarios:
- running with rackup
- running with rackup -D
- running with rackup -D -s thin
- running with Foreman
