### PR TITLE
Add ability to turn each container title into a link

### DIFF
--- a/lib/tasseo/public/j/tasseo.js
+++ b/lib/tasseo/public/j/tasseo.js
@@ -186,13 +186,17 @@ function buildContainers() {
       falseTargets++;
     } else {
       var j = i - falseTargets;
-      $('.main').append(
+      var href_block = 'link' in metrics[i] ? '<a href="' + metrics[i].link + '">' : '';
+      var href_close = 'link' in metrics[i] ? '</a>' : '';
+      var div_block =
         '<div id="' + j + '" class="graph graph' + j + '">' +
         '<span class="description description' + j + '"></span>' +
+        href_block +
         '<div class="overlay-name overlay-name' + j + '"></div>' +
+        href_close +
         '<div class="overlay-number overlay-number' + j + '"></div>' +
-        '</div>'
-      );
+        '</div>';
+      $('.main').append(div_block);
     }
   }
 }


### PR DESCRIPTION
In cases where someone is using Tasseo as more of a dashboard than a radiator, this allows a top-level dashboard to link down to more component-specific dashboards or other additional info/follow-up.
