### PR TITLE
Reorganize to allow for alternate datasources

### DIFF
--- a/lib/tasseo/public/j/tasseo.js
+++ b/lib/tasseo/public/j/tasseo.js
@@ -230,6 +230,65 @@ TasseoGraphiteDatasource.prototype = {
   }
 }
 
+
+/* Librato datasource */
+
+function TasseoLibratoDatasource(auth, options) {
+  this.auth = auth;
+  this.options = _.extend({}, options);
+  this.url = this.options.url || 'https://metrics-api.librato.com/v1/metrics';
+}
+
+TasseoLibratoDatasource.prototype = {
+  refresh: function(metrics, period) {
+    _.each(metrics, function(metric) {
+      this.refreshMetric(metric, period);
+    }, this)
+  },
+
+  refreshMetric: function(metric, period) {
+    var self = this;
+
+    $.ajax({
+      url: this.urlForMetric(metric, period),
+      beforeSend: function(xhr) {
+        if (self.auth && self.auth.length > 0) {
+          var bytes = Crypto.charenc.Binary.stringToBytes(self.auth);
+          var base64 = Crypto.util.bytesToBase64(bytes);
+          xhr.setRequestHeader('Authorization', 'Basic ' + base64);
+        }
+      },
+      dataType: 'json',
+      error: function(xhr, textStatus, errorThrown) { console.log(errorThrown); },
+      success: function(metricResult) {
+        var datapoints = metricResult.measurements[metric.source || "all"]
+        var newDatapoints = _.map(datapoints, function(datapoint) {
+          return { x: datapoint['measure_time'], y: datapoint['value'] }
+        })
+        metric.update(newDatapoints)
+      }
+    })
+  },
+
+  urlForMetric: function(metric, period) {
+    var now = Math.floor(new Date() / 1000),
+        start_time = now - (period * 60),
+        end_time = now;
+
+    var url = this.url + "/" + metric.target + "?start_time=" + start_time + "&end_time=" + end_time + "&resolution=1";
+
+    if (metric.source) {
+      url += "&source=" + metric.source;
+    } else {
+      url += "&summarize_sources=true&breakout_sources=false"
+    }
+
+    return url;
+  }
+}
+
+
+
 /* UI functionality */
 
 function TasseoUi(dashboard, options) {

--- a/lib/tasseo/views/index.haml
+++ b/lib/tasseo/views/index.haml
@@ -41,16 +41,25 @@
       .main
         %script{ :type => "text/javascript", :src => "dashboards/#{dashboard}.js" }
         :javascript
-          var url = "#{ENV['GRAPHITE_URL']}";
-          var auth = "#{ENV['GRAPHITE_AUTH']}";
+
+          var datasource;
+
+          var graphiteUrl = "#{ENV['GRAPHITE_URL']}";
+          var graphiteAuth = "#{ENV['GRAPHITE_AUTH']}";
+          var libratoAuth = "#{ENV['LIBRATO_AUTH']}";
+
+          if (libratoAuth != "") {
+            datasource = new TasseoLibratoDatasource(libratoAuth)
+          } else {
+            var graphiteOptions = {}
+            if (typeof padnulls != 'undefined') graphiteOptions['padnulls'] = padnulls;
+            datasource = new TasseoGraphiteDatasource(graphiteUrl, graphiteAuth, graphiteOptions)
+          }
 
           /* gather all configuration settings from global variables and turn
            * them into proper options.
            */
           var period = (typeof period == 'undefined') ? 5 : period;
-
-          var graphiteOptions = {}
-          if (typeof padnulls != 'undefined') graphiteOptions['padnulls'] = padnulls;
 
           var dashboardOptions = {}
           if (typeof interpolation != 'undefined') dashboardOptions['interpolation'] = interpolation;
@@ -66,7 +75,6 @@
           if (typeof toolbar != 'undefined')                  uiOptions['toolbar'] = toolbar;
           if (typeof theme != 'undefined' && theme == "dark") uiOptions['darkMode'] = true;
 
-          var datasource = new TasseoGraphiteDatasource(url, auth, graphiteOptions)
           var dashboard = new TasseoDashboard(metrics, datasource, period, dashboardOptions)
           var ui = new TasseoUi(dashboard, uiOptions)
 


### PR DESCRIPTION
This change is intended to provide a way to implement alternate backends for tasseo.

The javascript has been split into 3 classes:
1. `TasseoDashboard` which is responsible for a collection of graphs
2. `TasseoGraphiteDatasource` which is responsible for fetching data from graphite
3. `TasseoUi` which is responsible for switching periods as well as day/night mode

Much of the code that was in `j/tasseo.js` that used global variables to configure aspects of operation have been moved to `index.haml` to allow for `j/tasseo.js` to be loaded in places that need more control over operation.
