### PR TITLE
Maintain the spin.gif animation if a metric is not found

### DIFF
--- a/lib/tasseo/public/j/tasseo.js
+++ b/lib/tasseo/public/j/tasseo.js
@@ -206,12 +206,18 @@ TasseoGraphiteDatasource.prototype = {
       error: function(xhr, textStatus, errorThrown) { console.log(errorThrown); },
       url: this.urlForMetrics(metrics, period)
     }).done(function(metricResults) {
-      _.each(metricResults, function(metricResult, idx) {
-        var metric = metrics[idx];
-        var newDatapoints = _.map(metricResult.datapoints, function(datapoint) {
-          return { x: datapoint[1], y: datapoint[0] }
-        })
-        metric.update(newDatapoints)
+      _.each(metrics, function(metric, idx) {
+        var metricResult = _.find(metricResults, function(metricResult) {
+          return ('keepLastValue(' + metric.target + ')') == metricResult.target;
+        });
+        if(metricResult === undefined) {
+          console.log("not found: " + metric.alias);
+        } else {
+          var newDatapoints = _.map(metricResult.datapoints, function(datapoint) {
+            return { x: datapoint[1], y: datapoint[0] }
+          })
+          metric.update(newDatapoints)
+        }
       })
     })
   },


### PR DESCRIPTION
After the ajax request, instead of iterating through the results,
that leads to missing metrics in graphite causing the graphs to
misalign, iterate through the configured metrics and extract the
corresponding value from the results hash.
