### PR TITLE
Fix InfluxDB query to latest

### DIFF
--- a/lib/tasseo/public/j/tasseo.js
+++ b/lib/tasseo/public/j/tasseo.js
@@ -275,7 +275,7 @@ TasseoInfluxDBDatasource.prototype = {
   urlForMetric: function(metric, period) {
     var self = this;
 
-    return this.url + '/series?time_precision=s&u=' + self.user + '&p=' + self.pass + '&q=select%20' + metric.target + '%20from%20data%20where%20time%20%3E%20now()%20-%20' + period + 'm%3B';
+    return this.url + '/series?time_precision=s&u=' + self.user + '&p=' + self.pass + '&q=select%20%2A%20from%20' + metric.target + '%20where%20time%20%3E%20now()%20-%20' + period + 'm%3B';
   }
 }
 


### PR DESCRIPTION
the new query syntax is apparently
select \* from _metric_name_ ...
