### PR TITLE
added a max parameter to control the graph y axis per graph

### DIFF
--- a/lib/tasseo/public/j/tasseo.js
+++ b/lib/tasseo/public/j/tasseo.js
@@ -74,7 +74,7 @@ function TasseoMetric(element, metricSpec, dashboardOptions) {
 
   this.element = element
   this.alias = this.alias || this.target;
-  this.max = this.max || 0;
+  this.max = this.max || null;
   this.transform = this.transform || function(value) { return value; };
   this.metricSpec = metricSpec
   this.dashboardOptions = dashboardOptions;
@@ -85,20 +85,36 @@ function TasseoMetric(element, metricSpec, dashboardOptions) {
 TasseoMetric.prototype = {
   clear: function() {
     this.datum = [{ x:0, y:0 }];
-    this.graph = new Rickshaw.Graph({
-      element: this.element,
-      width: this.dashboardOptions.graph_width || 348,
-      height: this.dashboardOptions.graph_height || 100,
-      interpolation: this.dashboardOptions.interpolation,
-      renderer: this.dashboardOptions.renderer,
-      stroke: this.dashboardOptions.stroke,
-      max: this.max,
-      series: [{
-        name: this.alias,
-        color: this.dashboardOptions.normalColor,
-        data: this.datum
-      }]
-    });
+    if (this.max) {	    
+      this.graph = new Rickshaw.Graph({
+        element: this.element,
+        width: this.dashboardOptions.graph_width || 348,
+        height: this.dashboardOptions.graph_height || 100,
+        interpolation: this.dashboardOptions.interpolation,
+        renderer: this.dashboardOptions.renderer,
+        stroke: this.dashboardOptions.stroke,
+        max: this.max,
+        series: [{
+          name: this.alias,
+          color: this.dashboardOptions.normalColor,
+          data: this.datum
+        }]
+      });
+    } else {
+      this.graph = new Rickshaw.Graph({
+        element: this.element,
+        width: this.dashboardOptions.graph_width || 348,
+        height: this.dashboardOptions.graph_height || 100,
+        interpolation: this.dashboardOptions.interpolation,
+        renderer: this.dashboardOptions.renderer,
+        stroke: this.dashboardOptions.stroke,
+        series: [{
+          name: this.alias,
+          color: this.dashboardOptions.normalColor,
+          data: this.datum
+        }]
+      });
+    }
 
     this.graph.render();
   },


### PR DESCRIPTION
Presently the y axis maximum on graphs will be dependent on the sample of data in the time period visible to the graph. This optional parameter will allow you to fix the max height per graph.

{
    "alias": "pulse-events-per-second",
    "target": "pulse.pulse-events-per-second",
    "warning": 100,
    "critical": 500,
    "max": 600
}

While you could set the max to be the critical value, that won't satisfy cases where Tasseo knows that you have a reverse threshold critical (warning higher than critical).
