### PR TITLE
eagerly load the data before the first refreshInterval has elapsed

### DIFF
--- a/lib/tasseo/public/j/tasseo.js
+++ b/lib/tasseo/public/j/tasseo.js
@@ -381,6 +381,7 @@ TasseoUi.prototype = {
   start: function() {
     if (!this.refreshId) {
       this.refreshId = setInterval(_.bind(dashboard.refreshData, dashboard), this.options.refreshInterval);
+      _.bind(dashboard.refreshData, dashboard)(); //fire an initial call
     }
 
     // set our 'live' interval hint


### PR DESCRIPTION
load the dashboard data immediately instead of waiting for the interval to elapse the first time.
If someone has a higher refresh interval they can be looking at spinning circles for a while.
