### PR TITLE
use metric alias to find metrics instead of relying on target attribute

### DIFF
--- a/lib/tasseo/public/j/tasseo.js
+++ b/lib/tasseo/public/j/tasseo.js
@@ -209,7 +209,7 @@ TasseoGraphiteDatasource.prototype = {
     }).done(function(metricResults) {
       _.each(metrics, function(metric, idx) {
         var metricResult = _.find(metricResults, function(metricResult) {
-          return ('keepLastValue(' + metric.target + ')') == metricResult.target;
+          return ('keepLastValue(' + metric.alias + ')') == metricResult.target;
         });
         if(metricResult === undefined) {
           console.log("not found: " + metric.alias);
@@ -225,10 +225,12 @@ TasseoGraphiteDatasource.prototype = {
 
   urlForMetrics: function(metrics, period) {
     var targets = _.map(metrics, function(metric) {
+      var wrap_alias = function(metric) { return "alias(" + encodeURI(metric.target) + ", '" + metric.alias + "')" ; };
+
       if (this.options.padnulls) {
-        return 'target=keepLastValue(' + encodeURI(metric.target) + ')'
+        return 'target=keepLastValue(+' + wrap_alias(metric) + ')';
       } else {
-        return 'target=' + encodeURI(metric.target)
+        return 'target=' + wrap_alias(metric);
       }
     }, this).join("&");
 


### PR DESCRIPTION
Sometimes graphite changes the target attribute it returns, so tasseo should not rely on it to find the data points.

This PR makes tasseo use the alias, which I think it is cleaner.

For example, if you try to use the following tasseo.metric.target:

```
scaleToSeconds(timeShift(stats.timers.rails.requests.count, '-30seconds'),1))
```

Graphite will return something like (**notice the quotes**):

```
scaleToSeconds(timeShift(stats.timers.rails.requests.count, -30seconds),1))
```

So it won't work, because tasseo can't find this metric in the response using the target it sent.

With this PR, graphite will always return `target: <alias>` so we can use `metric.alias` to find the data points in `metricResults`.
