### PR TITLE
@obfuscurity => Check for undefined 'usingCloudWatch' value #minor

### DIFF
--- a/lib/tasseo/views/index.haml
+++ b/lib/tasseo/views/index.haml
@@ -58,7 +58,7 @@
             datasource = new TasseoLibratoDatasource(libratoAuth)
           } else if (influxDbUrl != "") {
             datasource = new TasseoInfluxDBDatasource(influxDbUrl, influxDbAuth)
-          } else if (usingCloudWatch) {
+          } else if (typeof usingCloudWatch != 'undefined' && usingCloudWatch) {
             datasource = new TasseoAWSCloudWatchDatasource(awsAccessKeyId, awsSecretAccessKey)
           } else {
             var graphiteOptions = {}


### PR DESCRIPTION
Sorry about this followup to https://github.com/obfuscurity/tasseo/pull/91. Forgot to check with an example that did not use Cloudwatch.

This fix will prevent a `Uncaught ReferenceError: usingCloudWatch is not defined` error, and thus not require non-Cloudwatch sources to set `var usingCloudWatch = false;` in their metric configurations.

Sorry for the oversight!
