### PR TITLE
@obfuscurity => Add ability to scale charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Metric-level attributes are attributes of the metric object(s) in your `metrics`
 * unit - Arbitrary string that can be used to designate a unit value; for example, "Mbps". (optional)
 * series - Name of the InfluxDB series that each target belongs to. (mandatory for InfluxDB)
 * transform - A function that takes the value and returns a transformed value. (optional)
+* scale - Use a dynamic y-axis scale rather than defaulting to zero min. (optional)
 * where - A `where` clause to pass to InfluxDB. (optional for InfluxDB)
 * Amazon CloudWatch specific fields which are documented [here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricStatistics.html) and are discussed in the *Amazon CloudWatch* section below
   * Namespace, MetricName, Dimensions, Statistics, EndTime, StartTime, Period, Unit
@@ -209,7 +210,9 @@ var metrics =
     transform: function(value) {
       // metric is logged in MB but we want to display GB
       return value / 1024;
-    }
+    },
+    // minimum y axis value will equal minimum metric y value (instead of 0)
+    scale: true
   }
 ]
 ```

--- a/lib/tasseo/public/j/tasseo.js
+++ b/lib/tasseo/public/j/tasseo.js
@@ -75,6 +75,7 @@ function TasseoMetric(element, metricSpec, dashboardOptions) {
   this.element = element
   this.alias = this.alias || this.target;
   this.transform = this.transform || function(value) { return value; };
+  this.scale = this.scale || false;
   this.metricSpec = metricSpec
   this.dashboardOptions = dashboardOptions;
 
@@ -112,6 +113,13 @@ TasseoMetric.prototype = {
       this.datum.length = 0
       Array.prototype.push.apply(this.datum, newDatum)
     }
+  },
+
+  datumMin: function() {
+    return _.chain(this.datum)
+      .map(function(pt) { return pt.y })
+      .min()
+      .value()
   },
 
   update: function(newData) {
@@ -153,6 +161,10 @@ TasseoMetric.prototype = {
   redraw: function() {
     var element = $(this.element);
 
+    // scale our graph so that the min is not 0
+    if (this.scale) {
+      this.graph.configure({ min: this.datumMin() });
+    }
     // update our graph
     this.graph.update();
 


### PR DESCRIPTION
I have a few metrics that are increasing in increments that are a very small proportion of the metric, ex: `[3.0, 3.0001, 3.0002, 3.0003...]`. Since the [default minimum of Rickshaw](https://github.com/shutterstock/rickshaw#min) is 0, the graph for this kind of data looks like:

![screen shot 2014-12-05 at 5 04 32 pm](https://cloud.githubusercontent.com/assets/4393191/5323983/932b644a-7ca3-11e4-91fe-0776ff404b71.png)

This PR adds a change where the minimum value on the graph will be the minimum value in the metric y values, if the optional metric arg `scale = true` is set in the dashboard. The same graph will then look like:

![screen shot 2014-12-05 at 5 04 13 pm](https://cloud.githubusercontent.com/assets/4393191/5324005/bf4c1380-7ca3-11e4-8ca1-92ac5cc93341.png)

which is more informative.

Since this is a display issue, I chose to change the min value on the graph rather than manipulate the actual datum with some sort of function like `transform`.
