### PR TITLE
Fix period for InfluxDB backend

### DIFF
--- a/lib/tasseo/public/j/tasseo.js
+++ b/lib/tasseo/public/j/tasseo.js
@@ -288,7 +288,7 @@ TasseoInfluxDBDatasource.prototype = {
   urlForMetric: function(metric, period) {
     var self = this;
 
-    var query = 'select ' + metric.target + ' from ' + metric.series + ' where time > now() - 5m';
+    var query = 'select ' + metric.target + ' from ' + metric.series + ' where time > now() - ' + period + 'm';
     if (metric.where) {
       query += ' and (' + metric.where + ')';
     }


### PR DESCRIPTION
This change set allows the period for an InfluxDB query to be dynamic vs. a hard coded 5 minutes.